### PR TITLE
bring emulator in line with bluetooth conventions and the current PM5 spec

### DIFF
--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -41,7 +41,7 @@ func (em *Emulator) RunEmulator() {
 			d.AddService(s3)
 
 			// Advertise config name and service's UUIDs.
-			d.AdvertiseNameAndServices(config.NAME, []gatt.UUID{s1.UUID(), s2.UUID(), s3.UUID()})
+			d.AdvertiseNameAndServices(config.NAME, []gatt.UUID{gatt.MustParseUUID("CE060000-43E5-11E4-916C-0800200C9A66")})
 
 		default:
 		}

--- a/emulator/emulator.go
+++ b/emulator/emulator.go
@@ -43,9 +43,6 @@ func (em *Emulator) RunEmulator() {
 			// Advertise config name and service's UUIDs.
 			d.AdvertiseNameAndServices(config.NAME, []gatt.UUID{s1.UUID(), s2.UUID(), s3.UUID()})
 
-			// Advertise as an OpenBeacon iBeacon
-			d.AdvertiseIBeacon(gatt.MustParseUUID("CE061800-43E5-11E4-916C-0800200C9A66"), 1, 2, -59)
-
 		default:
 		}
 	}

--- a/service/control.go
+++ b/service/control.go
@@ -16,7 +16,6 @@ var (
 	attrControlServiceUUID, _          = gatt.ParseUUID(getFullUUID("0020"))
 	attrReceiveCharacteristicsUUID, _  = gatt.ParseUUID(getFullUUID("0021"))
 	attrTransmitCharacteristicsUUID, _ = gatt.ParseUUID(getFullUUID("0022"))
-	attrTransmitDescriptorUUID, _      = gatt.ParseUUID(getFullUUID("2902"))
 )
 
 //NewControlService advertises Control service offered by PM5
@@ -66,7 +65,6 @@ func NewControlService() *gatt.Service {
 		resp.Write(data)
 	})
 
-	transmitChar.AddDescriptor(attrTransmitDescriptorUUID).SetValue([]byte{})
 
 	return controlService
 }

--- a/service/gatt.go
+++ b/service/gatt.go
@@ -9,7 +9,6 @@ import (
 var (
 	attrGATTUUID, _             = gatt.ParseUUID(getFullUUID("1801"))
 	attrServiceChangedUUID, _   = gatt.ParseUUID(getFullUUID("2A05"))
-	attrGATTClientConfigChar, _ = gatt.ParseUUID(getFullUUID("2902"))
 )
 
 // NewGattService registers a new GATT service as per PM5 specs
@@ -23,7 +22,7 @@ func NewGattService() *gatt.Service {
 			}()
 		})
 
-	c.AddDescriptor(attrGATTClientConfigChar).HandleReadFunc(func(rsp gatt.ResponseWriter, req *gatt.ReadRequest) {
+	c.HandleReadFunc(func(rsp gatt.ResponseWriter, req *gatt.ReadRequest) {
 		logrus.Info("Handle Read")
 		rsp.Write([]byte{0x0,0x0}) //2 bytes
 	})

--- a/service/rowing.go
+++ b/service/rowing.go
@@ -14,7 +14,6 @@ import (
 var (
 	attrRowingServiceUUID, _                                    = gatt.ParseUUID(getFullUUID("0030"))
 	attrGeneralStatusCharacteristicsUUID, _                     = gatt.ParseUUID(getFullUUID("0031"))
-	attrGeneralStatusDescriptorUUID, _                          = gatt.ParseUUID(getFullUUID("2902"))
 	attrAdditionalStatus1CharacteristicsUUID, _                 = gatt.ParseUUID(getFullUUID("0032"))
 	attrAdditionalStatus2CharacteristicsUUID, _                 = gatt.ParseUUID(getFullUUID("0033"))
 	attrSampleRateCharacteristicsUUID, _                        = gatt.ParseUUID(getFullUUID("0034"))
@@ -44,7 +43,6 @@ func NewRowingService() *gatt.Service {
 			rsp.Write([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x80, 0x0})
 		})
 
-	rowingGenStatusChar.AddDescriptor(attrGeneralStatusDescriptorUUID).SetValue([]byte{})
 
 	/*
 		C2 rowing additional status 1 characteristic
@@ -55,7 +53,6 @@ func NewRowingService() *gatt.Service {
 		rsp.Write([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xb8, 0xb, 0x0, 0x0, 0x0})
 	})
 
-	additionalStatus1Char.AddDescriptor(attrGeneralStatusDescriptorUUID).SetValue([]byte{})
 
 	/*
 		C2 rowing additional status 2 characteristic
@@ -66,7 +63,6 @@ func NewRowingService() *gatt.Service {
 		rsp.Write([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
 	})
 
-	additionalStatus2Char.AddDescriptor(attrGeneralStatusDescriptorUUID).SetValue([]byte{})
 	/*
 		C2 rowing general status and additional status sample rate characteristic 0x0034
 	*/
@@ -86,7 +82,6 @@ func NewRowingService() *gatt.Service {
 		rsp.Write([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
 	})
 
-	strokeDataChar.AddDescriptor(attrGeneralStatusDescriptorUUID).SetValue([]byte{})
 
 	/*
 		C2 rowing additional stroke data characteristic 0x0036
@@ -97,7 +92,6 @@ func NewRowingService() *gatt.Service {
 		rsp.Write([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff})
 	})
 
-	additionalStrokeDataChar.AddDescriptor(attrGeneralStatusDescriptorUUID).SetValue([]byte{})
 
 	/*
 		C2 rowing split/interval data characteristic
@@ -109,7 +103,6 @@ func NewRowingService() *gatt.Service {
 		rsp.Write(data)
 	})
 
-	splitIntervalDataChar.AddDescriptor(attrGeneralStatusDescriptorUUID).SetValue([]byte{})
 
 	/*
 		C2 rowing additional split/interval data characteristic
@@ -121,7 +114,6 @@ func NewRowingService() *gatt.Service {
 		rsp.Write(data)
 	})
 
-	additionalSplitIntervalDataChar.AddDescriptor(attrGeneralStatusDescriptorUUID).SetValue([]byte{})
 	/*
 		C2 rowing end of workout summary data characteristic
 	*/
@@ -132,7 +124,6 @@ func NewRowingService() *gatt.Service {
 		rsp.Write(data)
 	})
 
-	endOfWorkoutSummaryDataChar.AddDescriptor(attrGeneralStatusDescriptorUUID).SetValue([]byte{})
 	/*
 		C2 rowing end of workout additional summary data characteristic
 	*/
@@ -143,7 +134,6 @@ func NewRowingService() *gatt.Service {
 		rsp.Write(data)
 	})
 
-	additionalEndOfWorkoutSummaryDataChar.AddDescriptor(attrGeneralStatusDescriptorUUID).SetValue([]byte{})
 
 	/*
 		C2 rowing heart rate belt information characteristic
@@ -161,8 +151,6 @@ func NewRowingService() *gatt.Service {
 		logrus.Info("received data at heart rate belt info: ", string(data))
 		return gatt.StatusSuccess
 	})
-
-	heartRateBeltInfoChar.AddDescriptor(attrGeneralStatusDescriptorUUID).SetValue([]byte{})
 
 	/*
 		C2 force curve data characteristic
@@ -198,7 +186,6 @@ func NewRowingService() *gatt.Service {
 		n.Write(m.HandleC2RowingGeneralStatus([]byte{}))
 	})
 
-	multiplexedInfoChar.AddDescriptor(attrGeneralStatusDescriptorUUID).SetValue([]byte{})
 
 	return s
 }

--- a/service/rowing.go
+++ b/service/rowing.go
@@ -58,7 +58,16 @@ func NewRowingService() *gatt.Service {
 		C2 rowing additional status 1 characteristic
 	*/
 	additionalStatus1Char := s.AddCharacteristic(attrAdditionalStatus1CharacteristicsUUID)
-
+	additionalStatus1Char.HandleNotifyFunc(func(r gatt.Request, n gatt.Notifier) {
+		logrus.Info("Additional Status 1 Char Notify Request - launching goroutine")
+		go func() {
+			for true {
+				logrus.Info("Sending Additional Status 1 Notification from goroutine")				
+				n.Write([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xb8, 0xb, 0x0, 0x0, 0x0})
+				time.Sleep(500 * time.Millisecond)
+			}
+		}()	
+	})
 
 	/*
 		C2 rowing additional status 2 characteristic

--- a/service/rowing.go
+++ b/service/rowing.go
@@ -4,6 +4,8 @@ import (
 	"pm5-emulator/service/mux"
 	"github.com/sirupsen/logrus"
 	"github.com/bettercap/gatt"
+	"time"
+	"crypto/rand"
 )
 
 /*
@@ -37,6 +39,20 @@ func NewRowingService() *gatt.Service {
 	*/
 	rowingGenStatusChar := s.AddCharacteristic(attrGeneralStatusCharacteristicsUUID)
 
+	rowingGenStatusChar.HandleNotifyFunc(
+		func(r gatt.Request, n gatt.Notifier) {
+			logrus.Info("General Status Char Notify Request - launching goroutine")
+			go func() {
+				for true {
+					logrus.Info("Sending General Status Char Notification from goroutine")
+					byteArray := make([]byte, 1)
+					rand.Read(byteArray)		
+					// 19 bytes		
+					n.Write([]byte{byteArray[0], 0x5, 0x5, 0x5, 0x5, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x5, 0x5, 0x5, 0x5})
+					time.Sleep(500 * time.Millisecond)
+				}
+			}()
+		})	
 
 	/*
 		C2 rowing additional status 1 characteristic
@@ -49,8 +65,16 @@ func NewRowingService() *gatt.Service {
 	*/
 	additionalStatus2Char := s.AddCharacteristic(attrAdditionalStatus2CharacteristicsUUID)
 	additionalStatus2Char.HandleNotifyFunc(func(r gatt.Request, n gatt.Notifier) {
-		logrus.Info("Additional Status 2 Char Notify Request")
-		n.Write([]byte{0x0, 0x1, 0x2, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
+		logrus.Info("Additional Status 2 Char Notify Request - launching goroutine")
+		go func() {
+			for true {
+				logrus.Info("Sending Additional Status 2 Notification from goroutine")
+				byteArray := make([]byte, 1)
+				rand.Read(byteArray)				
+				n.Write([]byte{byteArray[0], 0x1, 0x2, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
+				time.Sleep(500 * time.Millisecond)
+			}
+		}()	
 	})
 
 	/*

--- a/service/rowing.go
+++ b/service/rowing.go
@@ -48,6 +48,10 @@ func NewRowingService() *gatt.Service {
 		C2 rowing additional status 2 characteristic
 	*/
 	additionalStatus2Char := s.AddCharacteristic(attrAdditionalStatus2CharacteristicsUUID)
+	additionalStatus2Char.HandleNotifyFunc(func(r gatt.Request, n gatt.Notifier) {
+		logrus.Info("Additional Status 2 Char Notify Request")
+		n.Write([]byte{0x0, 0x1, 0x2, 0x3, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
+	})
 
 	/*
 		C2 rowing general status and additional status sample rate characteristic 0x0034

--- a/service/rowing.go
+++ b/service/rowing.go
@@ -36,32 +36,18 @@ func NewRowingService() *gatt.Service {
 		C2 rowing general status characteristic
 	*/
 	rowingGenStatusChar := s.AddCharacteristic(attrGeneralStatusCharacteristicsUUID)
-	rowingGenStatusChar.HandleReadFunc(
-		func(rsp gatt.ResponseWriter, req *gatt.ReadRequest) {
-			logrus.Info("General Status Char Read Request")
-			//19 bytes
-			rsp.Write([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x80, 0x0})
-		})
 
 
 	/*
 		C2 rowing additional status 1 characteristic
 	*/
 	additionalStatus1Char := s.AddCharacteristic(attrAdditionalStatus1CharacteristicsUUID)
-	additionalStatus1Char.HandleReadFunc(func(rsp gatt.ResponseWriter, req *gatt.ReadRequest) {
-		logrus.Info("Additional Status 1 Char Read Request")
-		rsp.Write([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xb8, 0xb, 0x0, 0x0, 0x0})
-	})
 
 
 	/*
 		C2 rowing additional status 2 characteristic
 	*/
 	additionalStatus2Char := s.AddCharacteristic(attrAdditionalStatus2CharacteristicsUUID)
-	additionalStatus2Char.HandleReadFunc(func(rsp gatt.ResponseWriter, req *gatt.ReadRequest) {
-		logrus.Info("Additional Status 2 Status Char Read Request")
-		rsp.Write([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
-	})
 
 	/*
 		C2 rowing general status and additional status sample rate characteristic 0x0034
@@ -77,95 +63,45 @@ func NewRowingService() *gatt.Service {
 		C2 rowing stroke data  characteristic 0x0035
 	*/
 	strokeDataChar := s.AddCharacteristic(attrStrokeDataCharacteristicsUUID)
-	strokeDataChar.HandleReadFunc(func(rsp gatt.ResponseWriter, req *gatt.ReadRequest) {
-		logrus.Info("Stroke Data char Read Request")
-		rsp.Write([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
-	})
 
 
 	/*
 		C2 rowing additional stroke data characteristic 0x0036
 	*/
 	additionalStrokeDataChar := s.AddCharacteristic(attrAdditionalStrokeDataCharacteristicsUUID)
-	additionalStrokeDataChar.HandleReadFunc(func(rsp gatt.ResponseWriter, req *gatt.ReadRequest) {
-		logrus.Info("Additional Stroke Data char Read Request")
-		rsp.Write([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff})
-	})
 
 
 	/*
 		C2 rowing split/interval data characteristic
 	*/
 	splitIntervalDataChar := s.AddCharacteristic(attrSplitIntervalDataCharacteristicsUUID)
-	splitIntervalDataChar.HandleReadFunc(func(rsp gatt.ResponseWriter, req *gatt.ReadRequest) {
-		logrus.Info("Split/Interval Data char Read Request")
-		data := make([]byte, 18)
-		rsp.Write(data)
-	})
 
 
 	/*
 		C2 rowing additional split/interval data characteristic
 	*/
 	additionalSplitIntervalDataChar := s.AddCharacteristic(attrAdditionalSplitIntervalDataCharacteristicsUUID)
-	additionalSplitIntervalDataChar.HandleReadFunc(func(rsp gatt.ResponseWriter, req *gatt.ReadRequest) {
-		logrus.Info("Additional Split/Interval Data char Read Request")
-		data := make([]byte, 18)
-		rsp.Write(data)
-	})
 
 	/*
 		C2 rowing end of workout summary data characteristic
 	*/
 	endOfWorkoutSummaryDataChar := s.AddCharacteristic(attrEndOfWorkoutSummaryDataCharacteristicsUUID)
-	endOfWorkoutSummaryDataChar.HandleReadFunc(func(rsp gatt.ResponseWriter, req *gatt.ReadRequest) {
-		logrus.Info("End of workout summary Data char Read Request")
-		data := make([]byte, 20)
-		rsp.Write(data)
-	})
 
 	/*
 		C2 rowing end of workout additional summary data characteristic
 	*/
 	additionalEndOfWorkoutSummaryDataChar := s.AddCharacteristic(attrAdditionalEndOfWorkoutSummaryDataCharacteristicsUUID)
-	additionalEndOfWorkoutSummaryDataChar.HandleReadFunc(func(rsp gatt.ResponseWriter, req *gatt.ReadRequest) {
-		logrus.Info("Additional End of workout summary Data char Read Request")
-		data := make([]byte, 19)
-		rsp.Write(data)
-	})
 
 
 	/*
 		C2 rowing heart rate belt information characteristic
 	*/
 	heartRateBeltInfoChar := s.AddCharacteristic(attrHeartRateBeltInfoCharacteristicsUUID)
-	//handle read
-	heartRateBeltInfoChar.HandleReadFunc(func(rsp gatt.ResponseWriter, req *gatt.ReadRequest) {
-		logrus.Info("Heart Rate Belt Info Read Request")
-		data := make([]byte, 6)
-		rsp.Write(data)
-	})
-
-	//handle write
-	heartRateBeltInfoChar.HandleWriteFunc(func(req gatt.Request, data []byte) (status byte) {
-		logrus.Info("received data at heart rate belt info: ", string(data))
-		return gatt.StatusSuccess
-	})
 
 	/*
 		C2 force curve data characteristic
 	*/
 	forceCurveDataChar := s.AddCharacteristic(attrForceCurveDataCharacteristicsUUID)
-	forceCurveDataChar.HandleReadFunc(func(rsp gatt.ResponseWriter, req *gatt.ReadRequest) {
-		logrus.Info("Force Curve Data Read Request")
-		data := make([]byte, 288)
-		rsp.Write(data)
-	})
-
-	forceCurveDataChar.HandleWriteFunc(func(req gatt.Request, data []byte) (status byte) {
-		logrus.Info("received data at force curve data: ", string(data))
-		return gatt.StatusSuccess
-	})
 
 	/*
 		C2 multiplexed information 	characteristic
@@ -173,11 +109,6 @@ func NewRowingService() *gatt.Service {
 		0x0080 | Up to 20 bytes | READ Permission
 	*/
 	multiplexedInfoChar := s.AddCharacteristic(attrMultiplexedInfoCharacteristicsUUID)
-	multiplexedInfoChar.HandleReadFunc(func(rsp gatt.ResponseWriter, req *gatt.ReadRequest) {
-		logrus.Info("Multiplexed Info Char")
-		m:=mux.Multiplexer{}
-		rsp.Write(m.HandleC2RowingGeneralStatus([]byte{}))
-	})
 
 	multiplexedInfoChar.HandleNotifyFunc(func(r gatt.Request, n gatt.Notifier) {
 		logrus.Info("Multiplex Info Char Notify Func")

--- a/service/rowing.go
+++ b/service/rowing.go
@@ -91,45 +91,124 @@ func NewRowingService() *gatt.Service {
 		C2 rowing stroke data  characteristic 0x0035
 	*/
 	strokeDataChar := s.AddCharacteristic(attrStrokeDataCharacteristicsUUID)
-
+	strokeDataChar.HandleNotifyFunc(func(r gatt.Request, n gatt.Notifier) {
+		logrus.Info("Stroke Data Char Notify Request - launching goroutine")
+		go func() {
+			for true {
+				logrus.Info("Stroke Data Notification from goroutine")
+				n.Write([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
+				time.Sleep(1000 * time.Millisecond)
+			}
+		}()	
+	})
 
 	/*
 		C2 rowing additional stroke data characteristic 0x0036
 	*/
 	additionalStrokeDataChar := s.AddCharacteristic(attrAdditionalStrokeDataCharacteristicsUUID)
-
+	additionalStrokeDataChar.HandleNotifyFunc(func(r gatt.Request, n gatt.Notifier) {
+		logrus.Info("Additional Stroke Data Char Notify Request - launching goroutine")
+		go func() {
+			for true {
+				logrus.Info("Stroke Data Notification from goroutine")
+				n.Write([]byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff})
+				time.Sleep(1000 * time.Millisecond)
+			}
+		}()	
+	})
 
 	/*
 		C2 rowing split/interval data characteristic
 	*/
 	splitIntervalDataChar := s.AddCharacteristic(attrSplitIntervalDataCharacteristicsUUID)
+	splitIntervalDataChar.HandleNotifyFunc(func(r gatt.Request, n gatt.Notifier) {
+		logrus.Info("Split/Interval Data Char Notify Request - launching goroutine")
+		go func() {
+			for true {
+				logrus.Info("Split/Interval Data Notification from goroutine")
+				n.Write(make([]byte, 18))
+				time.Sleep(50000 * time.Millisecond)
+			}
+		}()	
+	})
 
 
 	/*
 		C2 rowing additional split/interval data characteristic
 	*/
 	additionalSplitIntervalDataChar := s.AddCharacteristic(attrAdditionalSplitIntervalDataCharacteristicsUUID)
+	additionalSplitIntervalDataChar.HandleNotifyFunc(func(r gatt.Request, n gatt.Notifier) {
+		logrus.Info("Additional Split/Interval Data Char Notify Request - launching goroutine")
+		go func() {
+			for true {
+				logrus.Info("Additional Split/Interval Data Notification from goroutine")
+				n.Write(make([]byte, 18))
+				time.Sleep(50000 * time.Millisecond)
+			}
+		}()	
+	})
 
 	/*
 		C2 rowing end of workout summary data characteristic
 	*/
 	endOfWorkoutSummaryDataChar := s.AddCharacteristic(attrEndOfWorkoutSummaryDataCharacteristicsUUID)
+	endOfWorkoutSummaryDataChar.HandleNotifyFunc(func(r gatt.Request, n gatt.Notifier) {
+		logrus.Info("End of workout summary Data Char Notify Request - launching goroutine")
+		go func() {
+			for true {
+				time.Sleep(200000 * time.Millisecond)
+				logrus.Info("End of workout summary Data Notification from goroutine")
+				n.Write(make([]byte, 20))
+			}
+		}()	
+	})
 
 	/*
 		C2 rowing end of workout additional summary data characteristic
 	*/
 	additionalEndOfWorkoutSummaryDataChar := s.AddCharacteristic(attrAdditionalEndOfWorkoutSummaryDataCharacteristicsUUID)
+	additionalEndOfWorkoutSummaryDataChar.HandleNotifyFunc(func(r gatt.Request, n gatt.Notifier) {
+		logrus.Info("End of workout Additional summary Data Char Notify Request - launching goroutine")
+		go func() {
+			for true {
+				time.Sleep(200000 * time.Millisecond)
+				logrus.Info("End of workout Additional summary Data Notification from goroutine")
+				n.Write(make([]byte, 20))
+			}
+		}()	
+	})
 
 
 	/*
 		C2 rowing heart rate belt information characteristic
 	*/
 	heartRateBeltInfoChar := s.AddCharacteristic(attrHeartRateBeltInfoCharacteristicsUUID)
+	heartRateBeltInfoChar.HandleNotifyFunc(func(r gatt.Request, n gatt.Notifier) {
+		logrus.Info("Heart Rate Belt Info Char Notify Request - launching goroutine")
+		go func() {
+			for true {
+				logrus.Info("Heart Rate Belt Data Notification from goroutine")
+				n.Write(make([]byte, 6))
+				time.Sleep(100000 * time.Millisecond)
+
+			}
+		}()	
+	})
 
 	/*
 		C2 force curve data characteristic
 	*/
 	forceCurveDataChar := s.AddCharacteristic(attrForceCurveDataCharacteristicsUUID)
+	forceCurveDataChar.HandleNotifyFunc(func(r gatt.Request, n gatt.Notifier) {
+		logrus.Info("Force Curve Data Char Notify Request - launching goroutine")
+		go func() {
+			for true {
+				logrus.Info("Force Curve Data Notification from goroutine")
+				n.Write([]byte{0b000101001, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0})
+				time.Sleep(1000 * time.Millisecond)
+			}
+		}()	
+	})
 
 	/*
 		C2 multiplexed information 	characteristic

--- a/service/rowing.go
+++ b/service/rowing.go
@@ -96,6 +96,14 @@ func NewRowingService() *gatt.Service {
 		rsp.Write(data)
 	})
 
+	sampleRateChar.HandleWriteFunc(func(req gatt.Request, data []byte) (status byte) {
+		logrus.Info("Sample Rate Char Write Request: ", string(data))
+		if (len(data) > 1){
+			logrus.Error("Sample Rate Char Write Request received more than one byte")
+		}
+		return gatt.StatusSuccess
+	})
+
 	/*
 		C2 rowing stroke data  characteristic 0x0035
 	*/


### PR DESCRIPTION
In its current state, the emulated erg has a number of problems that prevent it from correctly working with pretty much any app that attempts to connect with a PM5. The problems that this PR corrects includes:

- This emulator isnt advertising the correct UUID's such that it can avoid being caught in UUID filters that apps use to remove non-erg devices from their lists.
- removes code to advertise the emulated erg as an iBeacon. Ergs are not iBeacons
- removes code manually setting the descriptor UUID for each characteristic. This is already handled by the Gatt library being used and doing this just adds useless duplicate information that can break things
- remove read handlers from characteristics, particularly in the rowing service, that the Concept2 bluetooth spec does not list as having read support.


**Testing:** Many of these changes were tested by comparing the advertising data from a real erg with the emulated erg using the nRF Connect android app.

**Details about some of these changes in case people are curious:**
This emulator advertises the UUID's of its services, whereas a real PM5 simply advertises the concept2 base UUID (CE06XXXX-43E5-11E4-916C-0800200C9A66, according to their bluetooth specification) with the placeholder (XXXX) values all set to 0. This causes devices to not see this emulator as an erg

This pull request also gets rid of advertising the erg as an Apple iBeacon, which may also have caused issues and just generally causes advertising data from the emulator to not match that from a real erg in apps such as nRF Connect that are intended to show this information. 







Thanks so much for building this! It is very useful for some work I have been doing lately and I look forward to contributing more in the future 