### PR TITLE
set default make target and improve compatability with other architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test:
 	@go test -v ./...
 
 build:
-	@GOOS=linux GOARCH=amd64 go build -o pm5-emulator cmd/pm5-emulator/main.go
+	go build -o pm5-emulator cmd/pm5-emulator/main.go
 	@echo "build complete use 'sudo ./pm5-emulator' to run"
 
 all: test build

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.DEFAULT_GOAL := all
+
 test:
 	@go test -v ./...
 


### PR DESCRIPTION
This is more of a small convenience change that i made on my own copy of the repo since I kept habitually typing `make` instead of `make all` (i used https://www.systutorials.com/how-to-change-the-default-target-of-make/ as the source for this change).

This also removes the hardcoded `GOOS` and `GOARCH` variables from the makefile to make this project more compatible with other platforms with GO installed, such as Raspberry pi, macOS, etc.

