### PR TITLE
add server config for macos

### DIFF
--- a/config/option/doc.go
+++ b/config/option/doc.go
@@ -1,0 +1,3 @@
+// Package option wraps the platform specific options to help
+// users creating cross-platform programs.
+package option

--- a/config/option/option_darwin.go
+++ b/config/option/option_darwin.go
@@ -1,0 +1,11 @@
+package option
+
+import "github.com/bettercap/gatt"
+
+var DefaultClientOptions = []gatt.Option{
+	gatt.MacDeviceRole(gatt.CentralManager),
+}
+
+var DefaultServerOptions = []gatt.Option{
+	gatt.MacDeviceRole(gatt.PeripheralManager),
+}

--- a/config/option/option_linux.go
+++ b/config/option/option_linux.go
@@ -1,0 +1,21 @@
+package option
+
+import (
+	"github.com/bettercap/gatt"
+	"github.com/bettercap/gatt/linux/cmd"
+)
+
+var DefaultClientOptions = []gatt.Option{
+	gatt.LnxMaxConnections(1),
+	gatt.LnxDeviceID(-1, true),
+}
+
+var DefaultServerOptions = []gatt.Option{
+	gatt.LnxMaxConnections(1),
+	gatt.LnxDeviceID(-1, true),
+	gatt.LnxSetAdvertisingParameters(&cmd.LESetAdvertisingParameters{
+		AdvertisingIntervalMin: 0x00f4,
+		AdvertisingIntervalMax: 0x00f4,
+		AdvertisingChannelMap:  0x7,
+	}),
+}

--- a/emulator/emulator_factory.go
+++ b/emulator/emulator_factory.go
@@ -3,9 +3,10 @@ package emulator
 import (
 	"log"
 	"pm5-emulator/sm"
+	"config/option"
+
 
 	"github.com/bettercap/gatt"
-	"github.com/bettercap/gatt/examples/option"
 )
 
 //NewEmulator factory methods initializes emulator

--- a/emulator/emulator_factory.go
+++ b/emulator/emulator_factory.go
@@ -5,7 +5,6 @@ import (
 	"pm5-emulator/sm"
 
 	"github.com/bettercap/gatt"
-	"github.com/bettercap/gatt/linux/cmd"
 )
 
 //NewEmulator factory methods initializes emulator
@@ -22,11 +21,5 @@ func NewEmulator() *Emulator {
 
 //BLE Server Options
 var defaultServerOptions = []gatt.Option{
-	gatt.LnxMaxConnections(1),
-	gatt.LnxDeviceID(-1, true),
-	gatt.LnxSetAdvertisingParameters(&cmd.LESetAdvertisingParameters{
-		AdvertisingIntervalMin: 0x00f4,
-		AdvertisingIntervalMax: 0x00f4,
-		AdvertisingChannelMap:  0x7,
-	}),
+	gatt.MacDeviceRole(gatt.PeripheralManager),
 }

--- a/emulator/emulator_factory.go
+++ b/emulator/emulator_factory.go
@@ -5,11 +5,12 @@ import (
 	"pm5-emulator/sm"
 
 	"github.com/bettercap/gatt"
+	"github.com/bettercap/gatt/examples/option"
 )
 
 //NewEmulator factory methods initializes emulator
 func NewEmulator() *Emulator {
-	d, err := gatt.NewDevice(defaultServerOptions...)
+	d, err := gatt.NewDevice(option.DefaultServerOptions...)
 	if err != nil {
 		log.Fatalf("Failed to open config, err: %s", err)
 	}
@@ -17,9 +18,4 @@ func NewEmulator() *Emulator {
 		device:       d,
 		stateMachine: sm.NewStateMachine(),
 	}
-}
-
-//BLE Server Options
-var defaultServerOptions = []gatt.Option{
-	gatt.MacDeviceRole(gatt.PeripheralManager),
 }


### PR DESCRIPTION
this updates the emulator factory to refer to the platform-based config provided in bettercap/gatt.

Fixes #21 


Including something from another projects examples folder may be sketchy tho. if that's too sketchy, then maybe doing the same thing they do, but using files in our own repo (i.e. follow/copy their example) may be better 