### PR TITLE
fix a bad golang assumption

### DIFF
--- a/emulator/emulator_factory.go
+++ b/emulator/emulator_factory.go
@@ -3,7 +3,7 @@ package emulator
 import (
 	"log"
 	"pm5-emulator/sm"
-	"config/option"
+	"pm5-emulator/config/option"
 
 
 	"github.com/bettercap/gatt"


### PR DESCRIPTION
#22 contained an assumption on my part that was based on other imports. I assumed it would just figure out what I meant since it seemed to do the same for other imports, but I admit I never actually tested it on macos.

this fixes that assumption